### PR TITLE
fix: webring rotation order

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,9 +105,9 @@
     <footer>
         
         <div class="webring">
-            <a href="https://n7webring.neocities.org/cece/next" title="Suivant&amp;middot;e">◀</a>
+            <a href="https://n7webring.neocities.org/cece/prev" title="Pr&amp;eacute;c&amp;eacute;dent&amp;middot;e" rel="ugc">◀</a>
             <a href="https://n7webring.neocities.org"><img src="https://n7webring.neocities.org/88x31.png" alt="students of n7"/></a>
-            <a  href="https://n7webring.neocities.org/cece/prev" title="Pr&amp;eacute;c&amp;eacute;dent&amp;middot;e">▶</a>
+            <a href="https://n7webring.neocities.org/cece/next" title="Suivant&amp;middot;e" rel="ugc">▶</a>
         </div>
 
         <p>My Portfolio >:) </p>


### PR DESCRIPTION
pour tourner dans le même sens que tout le monde 👀

(`rel="ugc"` pour [user generated content](https://developers.google.com/search/docs/crawling-indexing/qualify-outbound-links?hl=fr))